### PR TITLE
🚜  Use STORAGES["staticfiles"] instead of STATICFILES_STORAGE

### DIFF
--- a/config/settings.py-tpl
+++ b/config/settings.py-tpl
@@ -121,7 +121,11 @@ USE_TZ = True
 STATIC_ROOT = str(BASE_DIR.joinpath("static"))
 STATIC_URL = "/static/"
 STATICFILES_DIRS = (str(BASE_DIR.joinpath("frontend")),)
-# STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# STORAGES = {
+#    "staticfiles": {
+#         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+#     }
+# }
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = str(BASE_DIR.joinpath("media"))

--- a/conftest.py-tpl
+++ b/conftest.py-tpl
@@ -23,8 +23,11 @@ def use_test_settings(settings):
     # User a faster password hasher
     settings.PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
-    settings.STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.StaticFilesStorage"
-    )
+    settings.STORAGES = {
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"
+        }
+    }
+
 
     settings.WHITENOISE_AUTOREFRESH = True


### PR DESCRIPTION
To suppress the deprecated warnings.

Ref: https://docs.djangoproject.com/en/dev/releases/4.2/#id1