### PR TITLE
Bump Django constraint to <6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "django-prodserver[gunicorn]",
     "django-q2",
     "django-tailwind-cli",
-    "django<6.0",
+    "django<6.1",
     "environs[django]",
     "psycopg[binary]",
     "whitenoise",


### PR DESCRIPTION
Allows generated projects to use Django 6.0.x (template has no lockfile; constraint-only change).