### PR TITLE
Document enabled vs unused health checks

### DIFF
--- a/config/urls.py-tpl
+++ b/config/urls.py-tpl
@@ -11,6 +11,10 @@ urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
     path(
         "health/",
+        # We only enable the Database check here. django-health-check 4.x also
+        # ships Cache, DNS, Mail, and Storage checks, which we intentionally leave
+        # off. The Django-Q2 worker is health-checked separately by
+        # healthcheck-worker.sh (`manage qinfo`), not via a health_check backend.
         HealthCheckView.as_view(
             checks=[
                 "health_check.Database",


### PR DESCRIPTION
Adds a comment noting we enable only the Database health check (Cache/DNS/Mail/Storage are available in django-health-check 4.x but left off), and that the Django-Q2 worker is health-checked via healthcheck-worker.sh (qinfo).